### PR TITLE
Add new OAuth flow for addons to PDvis

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -1,12 +1,1 @@
-Addons can now use PagerDuty's OAuth service to authenticate users and get API tokens. PagerDuty uses the [OAuth2 Implicit Grant Flow](https://www.quora.com/How-does-OAuth-2-0-work/answer/Miguel-Paraz) for authentication.
-
-The PDvis addon gives an [example](https://github.com/PagerDuty/addons/pull/23) of how to add OAuth2 to your addon. Here's how the OAuth flow works from a high-level:
-1. Your addon requests an OAuth token by redirecting the user to PagerDuty's OAuth service (http://app.pagerduty.com/oauth/authorize) and supplying your app's `client_id`, `redirect_uri` and `state`. The user will then Authorize the addon. See [`requestOAuthToken`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R45).
-2. PagerDuty's OAuth service will then redirect the user back to your addon which will receive the generated OAuth `token` and `state` as hash parameters. Your addon must verify the `state` received from PagerDuty's OAuth service matches the state your addon sent in 1. Then it will store the `token` and use it to make API requests. See [`receiveOAuthToken`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R66).
-
-See [`main`](https://github.com/PagerDuty/addons/pull/23/files#diff-d4165290cddbf3212be36d99822dd88aR828) for an example of the flow from steps 1 and 2. When the addon is loaded, first it checks to see if a token already exists. If no token exists, it will check if the page is being loaded normally by a user trying to access the addon or if it's being loaded by a redirect
-from PagerDuty's OAuth service (step 2 above). If it's a normal page load, the addon starts the OAuth flow to request an OAuth token. If it's a redirect from PagerDuty's OAuth service, the addon receives the OAuth token and stores it so it can be used in API requests.
-
-Some notes:
-* If your addon gets an error with an API request about having a bad token, you can try to generate the token again by going back to step 1 from above. See [`PDRequest`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R104).
-* The `Authorization` header used in API requests is slightly different from before. See [`PDRequest`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R86)
+OAuth is in Beta, please contact John Baldo (jbaldo@pagerduty.com) for early access to OAuth registration.

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -1,0 +1,12 @@
+Addons can now use PagerDuty's OAuth service to authenticate users and get API tokens. PagerDuty uses the [OAuth2 Implicit Grant Flow](https://www.quora.com/How-does-OAuth-2-0-work/answer/Miguel-Paraz) for authentication.
+
+The PDvis addon gives an [example](https://github.com/PagerDuty/addons/pull/23) of how to add OAuth2 to your addon. Here's how the OAuth flow works from a high-level:
+1. Your addon requests an OAuth token by redirecting the user to PagerDuty's OAuth service (http://app.pagerduty.com/oauth/authorize) and supplying your app's `client_id`, `redirect_uri` and `state`. The user will then Authorize the addon. See [`requestOAuthToken`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R45).
+2. PagerDuty's OAuth service will then redirect the user back to your addon which will receive the generated OAuth `token` and `state` as hash parameters. Your addon must verify the `state` received from PagerDuty's OAuth service matches the state your addon sent in 1. Then it will store the `token` and use it to make API requests. See [`receiveOAuthToken`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R66).
+
+See [`main`](https://github.com/PagerDuty/addons/pull/23/files#diff-d4165290cddbf3212be36d99822dd88aR828) for an example of the flow from steps 1 and 2. When the addon is loaded, first it checks to see if a token already exists. If no token exists, it will check if the page is being loaded normally by a user trying to access the addon or if it's being loaded by a redirect
+from PagerDuty's OAuth service (step 2 above). If it's a normal page load, the addon starts the OAuth flow to request an OAuth token. If it's a redirect from PagerDuty's OAuth service, the addon receives the OAuth token and stores it so it can be used in API requests.
+
+Some notes:
+* If your addon gets an error with an API request about having a bad token, you can try to generate the token again by going back to step 1 from above. See [`PDRequest`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R104).
+* The `Authorization` header used in API requests is slightly different from before. See [`PDRequest`](https://github.com/PagerDuty/addons/pull/23/files#diff-073f48c76203d07dc39b9549aa405ff4R86)

--- a/PDvis/common.js
+++ b/PDvis/common.js
@@ -1,10 +1,14 @@
-function getParameterByName(name, source) {
-    if (typeof source === 'undefined') {
-      source = location.search;
-    }
+function getParameterByName(name) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-        results = regex.exec(source);
+    results = regex.exec(location.search);
+    return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+function getHashParameterByName(name, isHash) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\#&]" + name + "=([^&#]*)"),
+    results = regex.exec(location.hash);
     return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
@@ -42,17 +46,16 @@ function requestOAuthToken() {
   var state = generateRandomState(16);
   window.localStorage.setItem('pdvisClientState', state);
   var clientId = "b5236b4b54e5ec7b2b51cccc603174a2ac0b575f33753e04a2924dced669c03b";
-  var redirect_uri = "https://pagerduty.github.io/addons/PDvis/index.html";
+  var redirectUri = "https://pagerduty.github.io/addons/PDvis/index.html";
   var oauthRoute = "http://app.pagerduty.com/oauth/authorize?client_id=" + clientId + "&redirect_uri=" + redirectUri + "&response_type=token&state=" + state;
   window.location.href = oauthRoute;
 }
 
 function getOAuthResponseParams() {
   var oauthParams = {};
-  var hash = window.location.hash.replace(/^#/, '?');
-  var token = getParameterByName('access_token', hash);
+  var token = getHashParameterByName('access_token');
   if (token) oauthParams.token = token;
-  var state = getParameterByName('state', hash);
+  var state = getHashParameterByName('state');
   if (state) oauthParams.state = state;
 
   window.location.hash = '';

--- a/PDvis/common.js
+++ b/PDvis/common.js
@@ -24,7 +24,7 @@ function getParametersByName(name) {
     if ( matches.length < 1 ) {
 	    return null;
     }
-    
+
     return matches.map(function(match) {
 	    return decodeURIComponent(match.replace(/\+/g, " "));
     });
@@ -72,6 +72,11 @@ function receiveOAuthToken(oauthParams) {
   window.localStorage.setItem('pdvisOAuthToken', oauthParams.token);
 }
 
+function removeOAuthToken() {
+  window.localStorage.removeItem('pdvisOAuthToken');
+  window.localStorage.removeItem('pdvisClientState');
+}
+
 function getToken() {
   return window.localStorage.getItem('pdvisOAuthToken');
 }
@@ -102,7 +107,7 @@ function PDRequest(token, endpoint, method, options) {
 			console.log(alertStr);
 
 			console.log("Attempting to get new OAuth token");
-			window.localStorage.removeItem('pdvisOAuthToken');
+			removeOAuthToken();
 			requestOAuthToken();
 		}
 	},

--- a/PDvis/common.js
+++ b/PDvis/common.js
@@ -1,14 +1,14 @@
 function getParameterByName(name) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-    results = regex.exec(location.search);
+        results = regex.exec(location.search);
     return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
 function getHashParameterByName(name, isHash) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\#&]" + name + "=([^&#]*)"),
-    results = regex.exec(location.hash);
+        results = regex.exec(location.hash);
     return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
@@ -24,7 +24,7 @@ function getParametersByName(name) {
     if ( matches.length < 1 ) {
 	    return null;
     }
-
+    
     return matches.map(function(match) {
 	    return decodeURIComponent(match.replace(/\+/g, " "));
     });
@@ -81,7 +81,7 @@ function PDRequest(token, endpoint, method, options) {
 	var merged = $.extend(true, {}, {
 		type: method,
 		dataType: "json",
-		url: "http://api.pagerduty.com/" + endpoint,
+		url: "https://api.pagerduty.com/" + endpoint,
 		headers: {
 			"Authorization": "Bearer " + token,
 			"Accept": "application/vnd.pagerduty+json;version=2"
@@ -101,9 +101,9 @@ function PDRequest(token, endpoint, method, options) {
 
 			console.log(alertStr);
 
-      console.log("Attempting to get new OAuth token");
-      window.localStorage.removeItem('pdvisOAuthToken');
-      requestOAuthToken();
+			console.log("Attempting to get new OAuth token");
+			window.localStorage.removeItem('pdvisOAuthToken');
+			requestOAuthToken();
 		}
 	},
 	options);

--- a/PDvis/index.html
+++ b/PDvis/index.html
@@ -10,7 +10,11 @@
 		<link href="vis.css" rel="stylesheet">
 	</head>
 	<body>
-		<div class="container-fluid" style="padding-top: 20px;">									
+		<div style="padding-top: 20px; padding-left: 15px">
+			<button type="button" id="login" class="btn btn-default metric-button">Sign in to PagerDuty to get started</button>
+			<button type="button" id="logout" class="btn btn-default metric-button">Logout</button>
+		</div>
+		<div class="container-fluid" style="padding-top: 20px;" id="addon-content">
 			<div id="controls" class="row">
 				<div class="col-md-4">
 					Since: <input type="text" id="since"> Until: <input type="text" id="until">
@@ -79,7 +83,7 @@
 				</div>
 			</div>
 		</div>
-		
+
 		<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 		<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 		<script src="https://d3js.org/d3.v3.min.js"></script>

--- a/PDvis/vis.js
+++ b/PDvis/vis.js
@@ -138,7 +138,7 @@ function visualize(data, metric, since, until, includeLowUrgency) {
 
 			if ( punchcard[i][j].TTA.length ) {
 				dailyTotals[i].TTA = dailyTotals[i].TTA.concat(punchcard[i][j].TTA);
-				hourlyTotals[j].TTA = hourlyTotals[j].TTA.concat(punchcard[i][j].TTA);				
+				hourlyTotals[j].TTA = hourlyTotals[j].TTA.concat(punchcard[i][j].TTA);
 			}
 
 			var v = {
@@ -416,7 +416,7 @@ function drawWeekly(element, since, until, data, metric, hoverFormatter) {
         .on("click", function(d) {
 	        if ( d[metric] > 0 ) {
 		        var params = {
-			        token: getParameterByName('token'),
+			        token: getToken(),
 			        since: moment(d.weekOfLong, "MMMM DD, YYYY").weekday(0).toISOString(),
 			        until: moment(d.weekOfLong, "MMMM DD, YYYY").weekday(6).toISOString()
 		        }
@@ -585,7 +585,7 @@ function drawPunchcard(element, since, until, punchcard, metric, dailyTotals, ho
         .on("click", function(d) {
 	        if ( d[metric] > 0 ) {
 		        var params = {
-			        token: getParameterByName('token'),
+			        token: getToken(),
 			        since: $('#since').datepicker("getDate").toISOString(),
 			        until: $('#until').datepicker("getDate").toISOString(),
 			        day: d.day,
@@ -636,7 +636,7 @@ function drawPunchcard(element, since, until, punchcard, metric, dailyTotals, ho
         .on("click", function(d, i) {
 	        if ( d[metric] > 0 ) {
 		        var params = {
-			        token: getParameterByName('token'),
+			        token: getToken(),
 			        since: $('#since').datepicker("getDate").toISOString(),
 			        until: $('#until').datepicker("getDate").toISOString(),
 			        day: i
@@ -686,7 +686,7 @@ function drawPunchcard(element, since, until, punchcard, metric, dailyTotals, ho
         .on("click", function(d, i) {
 	        if ( d[metric] > 0 ) {
 		        var params = {
-			        token: getParameterByName('token'),
+			        token: getToken(),
 			        since: $('#since').datepicker("getDate").toISOString(),
 			        until: $('#until').datepicker("getDate").toISOString(),
 			        hour: i
@@ -826,6 +826,18 @@ function setProgressBar(progress) {
 }
 
 function main() {
+	debugger
+	var oauthResponseParams = getOAuthResponseParams()
+	if (!getToken()) {
+		if (oauthResponseParams.length == 0) {
+			requestOAuthToken();
+			return;
+		} else {
+			receiveOAuthToken(oauthResponseParams);
+		}
+	}
+	console.log('pdvisOAuthToken ' + window.localStorage.getItem('pdvisOAuthToken'));
+
 	$('#since').datepicker();
 	$('#until').datepicker();
 
@@ -856,7 +868,7 @@ function main() {
 					callback(null, 'yay');
 				}
 			}
-			PDRequest(getParameterByName('token'), 'users', 'GET', options);
+			PDRequest(getToken(), 'users', 'GET', options);
 		},
 		function(callback) {
 			$('#busy-message').html('<h1>Getting incidents and log entries...</h1>');

--- a/PDvis/vis.js
+++ b/PDvis/vis.js
@@ -826,7 +826,6 @@ function setProgressBar(progress) {
 }
 
 function main() {
-	debugger
 	if (!getToken()) {
 		var oauthResponseParams = getOAuthResponseParams();
 		if (!oauthResponseParams.token && !oauthResponseParams.state) {

--- a/PDvis/vis.js
+++ b/PDvis/vis.js
@@ -826,13 +826,34 @@ function setProgressBar(progress) {
 }
 
 function main() {
+	$('#login').click(function(e) {
+		requestOAuthToken();
+	});
+	$('#logout').click(function(e) {
+		removeOAuthToken();
+		$('#login').show();
+		$('#login-text').show();
+		$('#logout').hide();
+		$('#addon-content').hide();
+		$('.busy').hide();
+	});
+
 	if (!getToken()) {
 		var oauthResponseParams = getOAuthResponseParams();
 		if (!oauthResponseParams.token && !oauthResponseParams.state) {
-			requestOAuthToken();
+			// normal page load - when a user visits the addon page
+			$('#addon-content').hide();
+			$('.busy').hide();
+			$('#logout').hide();
 			return;
 		} else {
+			// page load when being redirected from PagerDuty OAuth service
 			receiveOAuthToken(oauthResponseParams);
+
+			$('#addon-content').show();
+			$('#logout').show();
+			$('#login').hide();
+			$('#login-text').hide();
 		}
 	}
 

--- a/PDvis/vis.js
+++ b/PDvis/vis.js
@@ -827,16 +827,15 @@ function setProgressBar(progress) {
 
 function main() {
 	debugger
-	var oauthResponseParams = getOAuthResponseParams()
 	if (!getToken()) {
-		if (oauthResponseParams.length == 0) {
+		var oauthResponseParams = getOAuthResponseParams();
+		if (!oauthResponseParams.token && !oauthResponseParams.state) {
 			requestOAuthToken();
 			return;
 		} else {
 			receiveOAuthToken(oauthResponseParams);
 		}
 	}
-	console.log('pdvisOAuthToken ' + window.localStorage.getItem('pdvisOAuthToken'));
 
 	$('#since').datepicker();
 	$('#until').datepicker();


### PR DESCRIPTION
@alisdair Please review. I tested both cases where the user generates a new OAuth token and where the user has a bad token and tries to make an API request (they get redirected to generate a new OAuth token).

Some questions:

1. What's the best way to generate the `state` [param](https://github.com/PagerDuty/addons/commit/306c8dec966eaadfb18ee23e697fc9f0d80bb7e9#diff-073f48c76203d07dc39b9549aa405ff4R30) for OAuth?

2. What's the best / most intuitive way to break up the OAuth logic in [`main`](https://github.com/PagerDuty/addons/commit/306c8dec966eaadfb18ee23e697fc9f0d80bb7e9#diff-d4165290cddbf3212be36d99822dd88aR829) so that addon devs who want to upgrade their addon to use OAuth can do so as easily as possible? I broke it up into `requestOAuthToken` and `receiveOAuthToken` methods to make the OAuth workflow easy to understand (making a request to the OAuth service, getting redirected to PagerDuty and authorizing the addon, getting redirected back to the app with the OAuth token and state).